### PR TITLE
fix: run extension on UI side to find sessions in WSL/SSH/containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/digitarald/vscode-session-trace"
   },
+  "extensionKind": ["ui"],
   "preview": true,
   "galleryBanner": {
     "color": "#1e1e2e",


### PR DESCRIPTION
Set `extensionKind` to `["ui"]` so the extension host always runs on the client (Windows/macOS) side where VS Code stores chat session JSONL files. In remote scenarios (WSL, SSH, Dev Containers) the extension was running on the remote side and looking for sessions in `~/.vscode-server`, which is empty.

Fixes #2