### PR TITLE
feat: add support for win32-arm64 in build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
             target: linux-arm64
           - os: windows-latest
             target: win32-x64
+          - os: windows-latest
+            target: win32-arm64
           - os: macos-latest
             target: darwin-arm64
           - os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
             target: linux-arm64
           - os: windows-latest
             target: win32-x64
+          - os: windows-latest
+            target: win32-arm64
           - os: macos-latest
             target: darwin-arm64
           - os: ubuntu-latest


### PR DESCRIPTION

<img width="839" height="132" alt="image" src="https://github.com/user-attachments/assets/ae5f0f04-a5f7-4fed-bda5-96b2f166eb25" />

https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions